### PR TITLE
fix: move Render func to asset package

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,21 +79,7 @@ func (*render) Render(opts *plugin.Options, args []string) error {
 		return err
 	}
 
-	return Render(opts.AssetDir, config)
-}
-
-func Render(assetDir string, config *asset.Config) error {
-	as, err := asset.NewDefaultAssets(*config)
-	if err != nil {
-		return err
-	}
-
-	err = as.WriteFiles(assetDir)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return asset.Render(opts.AssetDir, *config)
 }
 
 func validateRenderOpts() error {

--- a/pkg/asset/render.go
+++ b/pkg/asset/render.go
@@ -1,0 +1,15 @@
+package asset
+
+func Render(assetDir string, config Config) error {
+	as, err := NewDefaultAssets(config)
+	if err != nil {
+		return err
+	}
+
+	err = as.WriteFiles(assetDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This function is not importable if it is in the plugin program. This
moves it to the asset package.