### PR TITLE
Dual-stack support

### DIFF
--- a/internal/templates.go
+++ b/internal/templates.go
@@ -739,8 +739,11 @@ spec:
         - --cluster-cidr={{ .PodCIDRsString }}
         - --hostname-override=$(NODE_NAME)
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --proxy-mode=iptables
+        - --proxy-mode={{ .ProxyMode }}
         - --conntrack-max-per-core=0
+        {{- range $k, $v := .ProxyExtraArgs }}
+        - --{{ $k }}={{ $v }}
+        {{- end }}
         env:
           - name: NODE_NAME
             valueFrom:
@@ -1024,7 +1027,33 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: {{ .DNSServiceIPsString }}
+  clusterIP: {{ .DNSServiceIPString }}
+  ports:
+    - name: dns
+      port: 53
+      protocol: UDP
+    - name: dns-tcp
+      port: 53
+      protocol: TCP
+`)
+
+var CoreDNSv6SvcTemplate = []byte(`apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dnsv6
+  namespace: kube-system
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9153"
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  clusterIP: {{ .DNSServiceIPv6String }}
+  ipFamily: IPv6
   ports:
     - name: dns
       port: 53

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -117,6 +117,16 @@ func newDynamicAssets(conf Config) Assets {
 			MustCreateAssetFromTemplate(AssetPathCalicoClusterInformationsCRD, internal.CalicoClusterInformationsCRD, conf),
 			MustCreateAssetFromTemplate(AssetPathCalicoIPPoolsCRD, internal.CalicoIPPoolsCRD, conf))
 	}
+
+	// If we are dual-stack, we need additional IPv6 service definitions.
+	// (Single stack IPv6-only clusters do not need this, as they are handled by
+	// the normal services above.)
+	if containsNonLocalIPv6(conf.DNSServiceIPs) && len(conf.DNSServiceIPs) > 1 {
+		assets = append(assets,
+			MustCreateAssetFromTemplate(AssetPathCoreDNSv6Svc, internal.CoreDNSv6SvcTemplate, conf),
+		)
+	}
+
 	return assets
 }
 


### PR DESCRIPTION
Further improvements for dual-stack support.

Primarily, this:
  - fixes services to have only a single clusterIP each
  - adds an IPv6 DNS service for dual-stack clusters
  - adds options to configure kube-proxy by asset.Config including `proxy-mode` and extra arguments
