### PR TITLE
fix: allow all seccomp profiles

### DIFF
--- a/internal/templates.go
+++ b/internal/templates.go
@@ -1733,6 +1733,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
   fsGroup:
     rule: RunAsAny


### PR DESCRIPTION
This adds an annotation to the default PSP that allows any seccomp
profile name to be used.