### PR TITLE
feat: update templates to use distroless images

### DIFF
--- a/internal/templates.go
+++ b/internal/templates.go
@@ -164,10 +164,10 @@ spec:
     spec:
       containers:
       - name: kube-apiserver
-        image: {{ .Images.Hyperkube }}
+        image: {{ .Images.KubeAPIServer }}
         command:
-        - /hyperkube
-        - kube-apiserver
+        - /go-runner
+        - /usr/local/bin/kube-apiserver
         - --enable-admission-plugins=PodSecurityPolicy,NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeClaimResize,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,Priority,NodeRestriction
         - --advertise-address=$(POD_IP)
         - --allow-privileged=true
@@ -253,10 +253,10 @@ metadata:
 spec:
   containers:
   - name: kube-apiserver
-    image: {{ .Images.Hyperkube }}
+    image: {{ .Images.KubeAPIServer }}
     command:
-    - /hyperkube
-    - kube-apiserver
+    - /go-runner
+    - /usr/local/bin/kube-apiserver
     - --advertise-address=$(POD_IP)
     - --allow-privileged=true
     - --authorization-mode=Node,RBAC
@@ -480,10 +480,10 @@ spec:
     spec:
       containers:
       - name: kube-controller-manager
-        image: {{ .Images.Hyperkube }}
+        image: {{ .Images.KubeControllerManager }}
         command:
-        - ./hyperkube
-        - kube-controller-manager
+        - /go-runner
+        - /usr/local/bin/kube-controller-manager
         - --use-service-account-credentials
         - --allocate-node-cidrs=true
         - --cloud-provider={{ .CloudProvider }}
@@ -569,10 +569,10 @@ metadata:
 spec:
   containers:
   - name: kube-controller-manager
-    image: {{ .Images.Hyperkube }}
+    image: {{ .Images.KubeControllerManager }}
     command:
-    - ./hyperkube
-    - kube-controller-manager
+    - /go-runner
+    - /usr/local/bin/kube-controller-manager
     - --allocate-node-cidrs=true
     - --cluster-cidr={{ .PodCIDRsString }}
     - --service-cluster-ip-range={{ .ServiceCIDRsString }}
@@ -639,10 +639,10 @@ spec:
     spec:
       containers:
       - name: kube-scheduler
-        image: {{ .Images.Hyperkube }}
+        image: {{ .Images.KubeScheduler }}
         command:
-        - ./hyperkube
-        - kube-scheduler
+        - /go-runner
+        - /usr/local/bin/kube-scheduler
         - --leader-elect=true
         - --profiling=false
         {{- range $k, $v := .SchedulerExtraArgs }}
@@ -677,10 +677,10 @@ metadata:
 spec:
   containers:
   - name: kube-scheduler
-    image: {{ .Images.Hyperkube }}
+    image: {{ .Images.KubeScheduler }}
     command:
-    - ./hyperkube
-    - kube-scheduler
+    - /go-runner
+    - /usr/local/bin/kube-scheduler
     - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
     - --leader-elect=true
     - --profiling=false
@@ -732,10 +732,9 @@ spec:
     spec:
       containers:
       - name: kube-proxy
-        image: {{ .Images.Hyperkube }}
+        image: {{ .Images.KubeProxy }}
         command:
-        - ./hyperkube
-        - kube-proxy
+        - /usr/local/bin/kube-proxy
         - --cluster-cidr={{ .PodCIDRsString }}
         - --hostname-override=$(NODE_NAME)
         - --kubeconfig=/etc/kubernetes/kubeconfig

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -308,9 +308,14 @@ type ImageVersions struct {
 	Calico          string
 	CalicoCNI       string
 	CoreDNS         string
-	Hyperkube       string
 	Kenc            string
 	PodCheckpointer string
+
+	Kubelet               string
+	KubeAPIServer         string
+	KubeControllerManager string
+	KubeProxy             string
+	KubeScheduler         string
 }
 
 // NewDefaultAssets returns a list of default assets, optionally

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -8,6 +8,11 @@ var DefaultImages = ImageVersions{
 	Calico:          "quay.io/calico/node:v3.0.3",
 	CalicoCNI:       "quay.io/calico/cni:v2.0.0",
 	CoreDNS:         "k8s.gcr.io/coredns:1.6.5",
-	Hyperkube:       "k8s.gcr.io/hyperkube:v1.16.2",
 	PodCheckpointer: "quay.io/coreos/pod-checkpointer:83e25e5968391b9eb342042c435d1b3eeddb2be1",
+
+	Kubelet:               "docker.io/autonomy/kubelet:v1.19.0-beta.1",
+	KubeAPIServer:         "k8s.gcr.io/kube-apiserver:v1.19.0-beta.1",
+	KubeControllerManager: "k8s.gcr.io/kube-controller-manager:v1.19.0-beta.1",
+	KubeProxy:             "k8s.gcr.io/kube-proxy:v1.19.0-beta.1",
+	KubeScheduler:         "k8s.gcr.io/kube-scheduler:v1.19.0-beta.1",
 }


### PR DESCRIPTION
This PR will update the asset templates for bootkube to use the new
distroless images, as well as our own image of kubelet. This is needed
because hyperkube is deprecated as of v1.19 of Kubernetes.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>